### PR TITLE
Initialize a randomly when omitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Two methods:
 - To install from source, first clone this repository.  Then, from the main repo folder, run `python setup.py install`
 
 ## Usage
-Fairly easy really `from snake.activations import Snake`.  The `Snake` constructor [(code here)](snake/activations.py) has an optional **learnable** parameter alpha which defaults to 1.  The authors of the paper find values between 5 and 50 work quite well for "known-periodic" data, while for better results with non-periodic data, you should choose a small value like 0.2.  The constructor also takes an `alpha_learnable` parameter which defaults to `True`, so that you can disable "learnability" if your experiments so require.  
+Fairly easy really `from snake.activations import Snake`.  The `Snake` constructor [(code here)](snake/activations.py) has a trainable parameter `a` controlling the frequency of the periodic term.  If `a` is omitted, each element of `a` is initialized from an exponential distribution.  The authors of the paper find values between 5 and 50 work quite well for "known-periodic" data, while for better results with non-periodic data, you should choose a small value like 0.2.  You can pass a fixed starting value for `a` (for example `Snake(features, a=5.0)`) and disable learning entirely by setting `trainable=False`.
 
 ## Sample code
 There's a notebook, still quite rough - [example.ipynb](example.ipynb).  Early indications are that good choices of hyperparameters are quite important for best results (though snake's own parameter trains quite readily).

--- a/snake/activations.py
+++ b/snake/activations.py
@@ -114,7 +114,7 @@ class Snake(Module):
 
         if a is None:
             # Initialize with Exponential distribution when no value is provided
-            initial_a = Exponential(torch.tensor(1.0)).sample(shape)
+            initial_a = Exponential(1.0).sample(shape)
         else:
             initial_a = torch.full(shape, float(a), dtype=torch.float32)
 

--- a/snake/activations.py
+++ b/snake/activations.py
@@ -109,16 +109,14 @@ class Snake(Module):
             in_features if isinstance(in_features, list) else [in_features]
         )
 
-        # Ensure initial_a is a floating point tensor
-        if isinstance(in_features, int):
-            initial_a = torch.full((in_features,), a, dtype=torch.float32)  # Explicitly set dtype to float32
-        else:
-            initial_a = torch.full(in_features, a, dtype=torch.float32)  # Assuming in_features is a list/tuple of dimensions
+        # Determine the tensor shape for parameter `a`
+        shape = tuple(self.in_features)
 
-        if trainable:
-            self.a = Parameter(initial_a)
+        if a is None:
+            # Initialize with Exponential distribution when no value is provided
+            initial_a = Exponential(torch.tensor(1.0)).sample(shape)
         else:
-            self.register_buffer('a', initial_a)
+            initial_a = torch.full(shape, float(a), dtype=torch.float32)
 
         if trainable:
             self.a = Parameter(initial_a)


### PR DESCRIPTION
## Summary
- randomize parameter `a` with an exponential distribution when not provided
- clarify usage docs for random init and `trainable` flag

## Testing
- `python -m compileall -q snake/activations.py`
- `pip install -r requirements.txt` *(failed: huge downloads)*

------
https://chatgpt.com/codex/tasks/task_e_687032ab3df88320b6831b838ddbf2eb